### PR TITLE
add PUID PGID Variables, /data path

### DIFF
--- a/funkwhale.xml
+++ b/funkwhale.xml
@@ -8,6 +8,7 @@
     [img src='https://raw.githubusercontent.com/thetarkus/docker-templates/master/images/funkwhale-logo.png']
 
     [font size=4]Funkwhale Docker Change Log[/font]
+    [b]2019-01-15:[/b] Add PUID, PGID variables and default /data to appdata/funkwhale
     [b]2019-01-11:[/b] Finish script for postgres
     [b]2019-01-10:[/b] Simplify environment variables
   </Changes>
@@ -54,7 +55,20 @@
       <ContainerDir>/music</ContainerDir>
       <Mode>ro</Mode>
     </Volume>
+        <Variable>
+      <Value>99</Value>
+      <Name>PUID</Name>
+      <Mode/>
+    </Variable>
+    <Variable>
+      <Value>100</Value>
+      <Name>PGID</Name>
+      <Mode/>
+    </Variable>
   </Data>
+  <Config Name="PUID" Target="PUID" Default="" Mode="" Description="Container Variable: PUID" Type="Variable" Display="advanced" Required="false" Mask="false">99</Config>
+  <Config Name="PGID" Target="PGID" Default="" Mode="" Description="Container Variable: PGID" Type="Variable" Display="advanced" Required="false" Mask="false">100</Config>
+  <Config Name="Data Path" Target="/data" Default="/mnt/user/appdata/funkwhale" Mode="rw" Description="Container Path: /config" Type="Path" Display="advanced-hide" Required="true" Mask="false">/mnt/user/appdata/funkwhale</Config>
   <Version></Version>
   <WebUI>http://[IP]:[PORT:3030]/</WebUI>
   <Icon>https://raw.githubusercontent.com/thetarkus/docker-templates/master/images/funkwhale-logo.png</Icon>

--- a/funkwhale.xml
+++ b/funkwhale.xml
@@ -33,6 +33,16 @@
       <Name>FUNKWHALE_URL</Name>
       <Value>yourdomain.funkwhale</Value>
     </Variable>
+    <Variable>
+      <Value>99</Value>
+      <Name>PUID</Name>
+      <Mode/>
+    </Variable>
+    <Variable>
+      <Value>100</Value>
+      <Name>PGID</Name>
+      <Mode/>
+    </Variable>
   </Environment>
   <Networking>
     <Mode>bridge</Mode>
@@ -55,20 +65,10 @@
       <ContainerDir>/music</ContainerDir>
       <Mode>ro</Mode>
     </Volume>
-        <Variable>
-      <Value>99</Value>
-      <Name>PUID</Name>
-      <Mode/>
-    </Variable>
-    <Variable>
-      <Value>100</Value>
-      <Name>PGID</Name>
-      <Mode/>
-    </Variable>
   </Data>
   <Config Name="PUID" Target="PUID" Default="" Mode="" Description="Container Variable: PUID" Type="Variable" Display="advanced" Required="false" Mask="false">99</Config>
   <Config Name="PGID" Target="PGID" Default="" Mode="" Description="Container Variable: PGID" Type="Variable" Display="advanced" Required="false" Mask="false">100</Config>
-  <Config Name="Data Path" Target="/data" Default="/mnt/user/appdata/funkwhale" Mode="rw" Description="Container Path: /config" Type="Path" Display="advanced-hide" Required="true" Mask="false">/mnt/user/appdata/funkwhale</Config>
+  <Config Name="Data Path" Target="/data" Default="/mnt/user/appdata/funkwhale" Mode="rw" Description="Container Path: /data" Type="Path" Display="advanced-hide" Required="true" Mask="false">/mnt/user/appdata/funkwhale</Config>
   <Version></Version>
   <WebUI>http://[IP]:[PORT:3030]/</WebUI>
   <Icon>https://raw.githubusercontent.com/thetarkus/docker-templates/master/images/funkwhale-logo.png</Icon>


### PR DESCRIPTION
adds the PUID and PGID Variables to the template (Unraid mostly uses 99 and 100 (nobody users))

Sets the default path for /data to /mnt/appdata/funkwhale
(standard for unraid)

Move these settings into the hidden "Advanced" part of the Template